### PR TITLE
Update bundler before running Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
   - 1.9.3
+before_install:
+  - gem install bundler


### PR DESCRIPTION
Travis builds have been failing with the following error:

```
NoMethodError: undefined method `spec' for nil:NilClass
```

By default Travis includes an older version of bundler (1.7.6)
that has a bug that causes the above error. This adds a before_install
step to .travis.yml that updates bundler and avoids the error.

With thanks to:

https://github.com/rubygems/rubygems/issues/1419
https://github.com/danmayer/coverband/pull/38
